### PR TITLE
updating the devDependencies, so grunt does not throw a fatal error on less compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
         "jquery-ui": "~1.8.0"
     },
     "devDependencies": {
-        "grunt": "~0.4.1",
-        "grunt-contrib-jshint": "~0.4.3",
-        "grunt-contrib-uglify": "~0.2.1",
-        "grunt-contrib-less": "~0.2.1"
+        "grunt": "~0.4.5",
+        "grunt-contrib-jshint": "~0.11.0",
+        "grunt-contrib-uglify": "~0.7.0",
+        "grunt-contrib-less": "~1.0.0"
     },
     "keywords": [
         "color",


### PR DESCRIPTION
With the old version of less, the grunt task could not be run, so I updated to the most recent versions. The less and JS tasks work just fine with those versions.