### PR TITLE
only trigger color.mouseover as long as no color has been selected

### DIFF
--- a/js/evol.colorpicker.js
+++ b/js/evol.colorpicker.js
@@ -81,6 +81,9 @@ $.widget( "evol.colorpicker", {
 		strings: 'Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.'
 	},
 
+	// this is only true while showing the palette until color is chosen
+	_active: false,
+
 	_create: function() {
 		var that=this;
 		this._paletteIdx=this.options.defaultPalette=='theme'?1:2;
@@ -310,6 +313,7 @@ $.widget( "evol.colorpicker", {
 
 	showPalette: function() {
 		if(this._enabled){
+			this._active=true;
 			$('.colorPicker').not('.'+this._id).colorpicker('hidePalette');
 			if(this._palette===null){
 				this._palette=this.element.next()
@@ -365,6 +369,7 @@ $.widget( "evol.colorpicker", {
 				if(that._enabled){
 					var $this=$(this);
 					that._setValue($this.hasClass('evo-transparent')?transColor:toHex3($this.attr('style').substring(17)));
+					that._active=false;
 				}
 			})
 			.on('mouseover', sel, function(evt){
@@ -374,7 +379,9 @@ $.widget( "evol.colorpicker", {
 					if(that.options.displayIndicator){
 						that._setColorInd(c,2);
 					}
-					that.element.trigger('mouseover.color', c);
+					if(that._active){
+						that.element.trigger('mouseover.color', c);
+					}
 				}
 			})
 			.find('.evo-more a').on('click', function(){


### PR DESCRIPTION
Thanks for the great plugin!

I was binding to the mouseover event to change the background-color of the row the colorpicker is in. The problem was that once the user clicks a color, I want the row to remain the selected color. However, if the user moves the mouse slightly between the click and the palette being hidden, my row would change color again to the final color the mouse rested on before the palette vanished.

I changed it so the mouseover event is only triggered until the point where the color is chosen. Since I assume this is the behavior other users would also expect, I'm sending a pull request.

Btw: some more options would be great, e.g. to disable the "web colors" link (or the other way around if you're using theme colors) and also to get rid of the strings and the standard colors. Some meaningfull css classes would do the trick as well. I don't have more time right now and I don't know if you would want the changes anyway so no pull request for that right now :)

Thanks again!