### PR TITLE
Add InitialHistory values

### DIFF
--- a/js/evol.colorpicker.js
+++ b/js/evol.colorpicker.js
@@ -145,6 +145,11 @@ $.widget( "evol.colorpicker", {
 		if(color && this.options.history){
 			this._add2History(color);
 		}
+	        if (this.options.initialHistrory) {
+	            var c = this.options.initialHistrory;
+	            for (var i in c)
+	                this._add2History(c[i]);
+	        }
 	},
 
 	_paletteHTML: function() {


### PR DESCRIPTION
If you wish to keep the history past page refreshes and session, you can store the values in db and retrieve it and add the initialisation options like:  .colorpicker({initialHistrory: ['#FF0000','#00BB00']});