### PR TITLE
Change the value only when needed and raise the "change" event

### DIFF
--- a/js/evol.colorpicker.js
+++ b/js/evol.colorpicker.js
@@ -98,10 +98,10 @@ $.widget( "evol.colorpicker", {
 					style='';
 				this._isPopup=true;
 				this._palette=null;
+				var v=e.val();
 				if(color!==null){
-					e.val(color);
+					if (color != v) e.val(color).change();
 				}else{
-					var v=e.val();
 					if(v!==''){
 						color=this.options.color=v;
 					}
@@ -413,7 +413,7 @@ $.widget( "evol.colorpicker", {
 			if(!noHide){
 				this.hidePalette();
 			}
-			this._setBoxColor(this.element.val(c).next(), c);
+			this._setBoxColor(this.element.val(c).change().next(), c);
 		}else{
 			this._setColorInd(c,1);
 		}


### PR DESCRIPTION
Adding this plugin to existing input text forms was breaking some
javascript depending on the change event being called.

When I add evol-colorpicker to existing forms having "javascript/change" logic bound to input values, the logic stops responding. Is there an use-case for not calling the change event when you change the value using the popup?