### PR TITLE
Prevent focusing the text field (don't open virtual keyboard on touch devices)

### DIFF
--- a/js/evol.colorpicker.js
+++ b/js/evol.colorpicker.js
@@ -133,6 +133,7 @@ $.widget( "evol.colorpicker", {
 					e.next().on('click', function(evt){
 						evt.stopPropagation();
 						that.showPalette();
+						return false;
 					});
 				}
 				break;
@@ -328,6 +329,7 @@ $.widget( "evol.colorpicker", {
 					.after(this._paletteHTML()).next()
 					.on('click',function(evt){
 						evt.stopPropagation();
+						return false;
 					});
 				this._bindColors();
 				var that=this;


### PR DESCRIPTION
Stop focusing the input field when opening the popup or selecting a new
color from the popup (this is critical on touch devices where the focus
opens the virtual keyboard).