### PR TITLE
Add .nuspec and nuget publish workflows

### DIFF
--- a/.github/workflows/create-nuget-package.yml
+++ b/.github/workflows/create-nuget-package.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/create-nuget-package.yml
+++ b/.github/workflows/create-nuget-package.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          mono nuget.exe push evol-colorpicker.3.4.3.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $NUGET_API_KEY
+          mono nuget.exe push evol-colorpicker.3.4.3-alpha1.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $NUGET_API_KEY

--- a/.github/workflows/create-nuget-package.yml
+++ b/.github/workflows/create-nuget-package.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create NuGet package
         run: |
-          mono nuget.exe pack evol-colorpicker.nuspec
+          mono nuget.exe pack .nuspec
 
       - name: Upload NuGet package
         env:

--- a/.github/workflows/create-nuget-package.yml
+++ b/.github/workflows/create-nuget-package.yml
@@ -1,0 +1,34 @@
+name: Create NuGet Package
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Install NuGet CLI
+        run: |
+          wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+          chmod +x nuget.exe
+
+      - name: Create NuGet package
+        run: |
+          mono nuget.exe pack evol-colorpicker.nuspec
+
+      - name: Upload NuGet package
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          mono nuget.exe push evol-colorpicker.3.4.3.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey $NUGET_API_KEY

--- a/.nuspec
+++ b/.nuspec
@@ -5,7 +5,7 @@
     <version>3.4.3</version>
     <authors>Olivier Giulieri</authors>
     <owners>Olivier Giulieri</owners>
-    <license type="file">LICENSE.txt</license>
+    <license type="file">LICENSE.md</license>
     <readme>README.md</readme>
     <projectUrl>http://evoluteur.github.io/colorpicker/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/.nuspec
+++ b/.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>evol-colorpicker</id>
+    <version>3.4.3</version>
+    <authors>Olivier Giulieri</authors>
+    <owners>Olivier Giulieri</owners>
+    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>http://evoluteur.github.io/colorpicker/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>jQuery UI widget for web color picking which looks like the one in Microsoft Office 2010.</description>
+    <tags>colorpicker color picker palette jquery jquery-ui ui widget popup web input form jquery-plugin</tags>
+  </metadata>
+  <files>
+    <file src="js/evol-colorpicker.min.js" target="content/scripts/" />
+  </files>
+</package>

--- a/.nuspec
+++ b/.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>evol-colorpicker</id>
-    <version>3.4.3</version>
+    <version>3.4.3-alpha1</version>
     <authors>Olivier Giulieri</authors>
     <owners>Olivier Giulieri</owners>
     <license type="file">LICENSE.md</license>
@@ -14,6 +14,7 @@
   </metadata>
   <files>
     <file src="js/evol-colorpicker.min.js" target="content/scripts/" />
+    <file src="css/evol-colorpicker.min.css" target="content/styles/" />
     <file src="LICENSE.md" target="LICENSE.md" />
     <file src="README.md" target="README.md" />
   </files>

--- a/.nuspec
+++ b/.nuspec
@@ -5,7 +5,8 @@
     <version>3.4.3</version>
     <authors>Olivier Giulieri</authors>
     <owners>Olivier Giulieri</owners>
-    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
+    <license type="file">LICENSE.txt</license>
+    <readme>README.md</readme>
     <projectUrl>http://evoluteur.github.io/colorpicker/</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>jQuery UI widget for web color picking which looks like the one in Microsoft Office 2010.</description>
@@ -13,5 +14,7 @@
   </metadata>
   <files>
     <file src="js/evol-colorpicker.min.js" target="content/scripts/" />
+    <file src="LICENSE.md" target="LICENSE.md" />
+    <file src="README.md" target="README.md" />
   </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ or install with Bower:
 bower install evol-colorpicker
 ```
 
+or use the [nuget package](https://www.nuget.org/packages/evol-colorpicker):
+
+```
+dotnet add package evol-colorpicker
+```
+
 <a name="Usage"></a>
 
 ## Usage


### PR DESCRIPTION
> Background: my org uses this internally and we only use nuget packages for this repo and didn't want to introduce npm as a dependency. I figured a simple PR could benefit anyone making use of this rather than doing something internal on our end!

I published a sample here: https://www.nuget.org/packages/evol-colorpicker for testing, but ideally @evoluteur you would create your own nuget API key and publish it yourself!

I hope its okay that I used your name in the test package.

Make sure to set your own API key to secrets.NUGET_API_KEY.